### PR TITLE
added routing skeleton for basic pages

### DIFF
--- a/react-app/ccf/src/App.tsx
+++ b/react-app/ccf/src/App.tsx
@@ -1,11 +1,57 @@
-import React from 'react';
-import logo from './logo.svg';
 import './App.css';
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 
-function App() {
+function App(): JSX.Element {
   return (
-    <div className="App">
-    </div>
+    <BrowserRouter>
+      <Routes>
+        {/* Default/Login page */}
+        <Route
+          path="/" 
+          element={
+            <></>
+          } 
+        />
+        <Route
+          path="/login" 
+          element={
+            <></>
+          } 
+        />
+        {/* 404 page */}
+        <Route
+          path="*" 
+          element={
+            <></>
+          } 
+        />
+        <Route
+          path="/forgot-password" 
+          element={
+            <></>
+          } 
+        />
+        <Route
+          path="/create-account" 
+          element={
+            <></>
+          } 
+        />        
+        <Route
+          path="/applicant-dashboard" 
+          element={
+            <></>
+          } 
+        />        
+        {/* Admin dashboard */}
+        <Route
+          path="/admin" 
+          element={
+            <></>
+          } 
+        />      
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/react-app/ccf/src/index.tsx
+++ b/react-app/ccf/src/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { initializeApp } from "firebase/app";


### PR DESCRIPTION
Only added routing for the pages that are currently being developed and are explicitly specified in the Webpages Breakdown in notion. Held off on routing other entities such as applicant and reviewer account page because these pages would require an authentication component to render the corresponding user page. With this component, would have "/" route to login page if user isn't authenticated and to "/dashboard" if user is authenticated. Additionally "/dashboard" would render either reviewer, applicant, or admin dashboard depending on authentication