### PR TITLE
Connected existing pdf upload functions to 3 application-form/ pages

### DIFF
--- a/react-app/ccf/src/pages/application-form/ApplicationForm.tsx
+++ b/react-app/ccf/src/pages/application-form/ApplicationForm.tsx
@@ -59,7 +59,7 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
     const renderPage = () => {
         switch (currentPage) {
             case 1:
-                return <GrantProposal type={type} />;
+                return <GrantProposal type={type} formData={formData} setFormData={setFormData} />;
             case 2:
                 return <AboutGrant type={type} formData={formData} />;
             case 3:

--- a/react-app/ccf/src/pages/application-form/subquestions/GrantProposal.tsx
+++ b/react-app/ccf/src/pages/application-form/subquestions/GrantProposal.tsx
@@ -1,15 +1,101 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import "./SubForm.css";
+import { uploadFileToStorage } from "../../../storage/storage";
 
 type GrantProposalProps = {
   type: "Research" | "NextGen";
+  formData: any;
+  setFormData: (data: any) => void;
 };
 
-function GrantProposal({ type }: GrantProposalProps): JSX.Element {
-  if (type === "Research") return (
+function GrantProposal({ type, formData, setFormData }: GrantProposalProps): JSX.Element {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [uploadStatus, setUploadStatus] = useState<string>("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files[0]) {
+      console.log("File selected:", event.target.files[0].name);
+      setSelectedFile(event.target.files[0]);
+      setFormData({ ...formData, file: event.target.files[0] });
+      setUploadStatus("");
+    }
+  };
+
+  const handleUpload = async () => {
+    console.log("Upload button pressed");
+    if (!selectedFile) {
+      console.log("No file selected for upload");
+      setUploadStatus("Please select a file first");
+      return;
+    }
+
+    try {
+      console.log("Starting file upload:", selectedFile.name);
+      setUploadStatus("Uploading...");
+      await uploadFileToStorage(selectedFile);
+      console.log("File uploaded successfully:", selectedFile.name);
+      setUploadStatus("File uploaded successfully!");
+    } catch (error) {
+      console.error("Upload error:", error);
+      setUploadStatus("Upload failed. Please try again.");
+    }
+  };
+
+  const handleDelete = () => {
+    console.log("Delete button pressed");
+    setSelectedFile(null);
+    setFormData({ ...formData, file: null });
+    setUploadStatus("");
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleUploadClick = () => {
+    console.log("Upload button clicked - opening file selector");
+    fileInputRef.current?.click();
+  };
+
+  const renderUploadSection = () => (
+    <div className="file-upload">
+      <label>Upload File (PDF Format)</label>
+      <br />
+      <br />
+      <div className="upload-btn-container">
+        <button 
+          className="upload-btn1" 
+          onClick={handleUploadClick}
+        >
+          {selectedFile ? selectedFile.name : "Click to upload"}
+        </button>
+        <input 
+          ref={fileInputRef}
+          type="file" 
+          accept=".pdf" 
+          onChange={handleFileChange}
+          style={{ display: "none" }} 
+          id="file-upload" 
+        />
+        {selectedFile && (
+          <button className="del-icon-container" onClick={handleDelete}>
+            <div className="del-icon"></div>
+          </button>
+        )}
+      </div>
+      {selectedFile && (
+        <button className="upload-btn1" onClick={handleUpload}>
+          Upload PDF
+        </button>
+      )}
+      {uploadStatus && <p className="upload-status">{uploadStatus}</p>}
+    </div>
+  );
+
+  const renderResearchContent = () => (
     <div className="form-container">
       <div className="proposal-text">
-      <p className="text-label">In the Grant Proposal, make sure to include:</p>
+        <p className="text-label">In the Grant Proposal, make sure to include:</p>
         <ul className="text-label"><b>1. Cover Sheet</b></ul>
         <ul className="text-label"><b>2. Narrative</b> (no more than 6 pages)</ul>
         <ul className="text-label"><b>3. References Cited</b> (not included in 6 pages)</ul>
@@ -19,46 +105,33 @@ function GrantProposal({ type }: GrantProposalProps): JSX.Element {
         <ul className="text-label"><b>7. Mentor's Letter of Commitment</b></ul>
         <ul className="text-label"><b>8. Support Letter from Sponsoring Institution</b> (Hospital or University Department Chair, Division Director, or Dean, or equivalent)</ul>
         <ul className="text-label"><b>9. NIH Biosketch</b></ul>
-      <br />
-      <p className="text-label">Format:</p>
-      <p className="text-label">
-        The Narrative of the proposal should not exceed 6 pages and should use NIH standard:
-        font 11 points or larger, no fewer than 6 lines per inch, and margins no smaller than 0.5”
-        (top, bottom, left, and right). It is recommended to use Arial, Georgia, Helvetica, or Palatino Linotype.
-      </p>
-      <br />
-      <br />
-      <div className="file-upload">
-        <label>Upload File (PDF Format)</label>
+        <br />
+        <p className="text-label">Format:</p>
+        <p className="text-label">
+          The Narrative of the proposal should not exceed 6 pages and should use NIH standard:
+          font 11 points or larger, no fewer than 6 lines per inch, and margins no smaller than 0.5"
+          (top, bottom, left, and right). It is recommended to use Arial, Georgia, Helvetica, or Palatino Linotype.
+        </p>
         <br />
         <br />
-        <div className="upload-btn-container">
-          <button className="upload-btn1">Click to upload</button>
-          <button className="del-icon-container">
-            <div className="del-icon"></div>
-          </button>
-        </div> 
+        {renderUploadSection()}
       </div>
-</div>
     </div>
   );
-  else return (
+
+  const renderNextGenContent = () => (
     <div className="form-container">
-    <div className="proposal-text">
-    <p className="text-label">In the Grant Proposal, make sure to include:</p>
+      <div className="proposal-text">
+        <p className="text-label">In the Grant Proposal, make sure to include:</p>
         <ul className="text-label"><b>1. Cover Sheet</b></ul>
         <ul><b>2. If Re-submission or renewal</b>
-        
-        
           <ol className="text-labe indent" type="a"><li><p className="text-label">
-          Please include a one (1) page Introduction. Applicants who have
-          received a previous CCF grant may apply for continued funding, but
-          must include the results of their current research, discuss the
-          progress made in prior year(s), and state how continued funding will
-          advance research in this area.
+            Please include a one (1) page Introduction. Applicants who have
+            received a previous CCF grant may apply for continued funding, but
+            must include the results of their current research, discuss the
+            progress made in prior year(s), and state how continued funding will
+            advance research in this area.
           </p></li></ol>
-          
-
         </ul>
         <ul className="text-label"><b>3. Narrative</b> (no more than 6 pages)</ul>
         <ul className="text-label"><b>4. References Cited</b> (not included in 6 pages)</ul>
@@ -66,29 +139,21 @@ function GrantProposal({ type }: GrantProposalProps): JSX.Element {
         <ul className="text-label"><b>8. Budget</b> (up to $75,000 for one year)</ul>
         <ul className="text-label"><b>7. Lay Summary</b> (1-2 pages recommended)</ul>
         <ul className="text-label"><b>9. NIH Biosketch</b></ul>
-      <br />
-      <p className="text-label">Format:</p>
-      <p className="text-label">
-        The Narrative of the proposal should not exceed 6 pages and should use NIH standard:
-        font 11 points or larger, no fewer than 6 lines per inch, and margins no smaller than 0.5”
-        (top, bottom, left, and right). It is recommended to use Arial, Georgia, Helvetica, or Palatino Linotype.
-      </p>
-      <br />
-      <br />
-      <div className="file-upload">
-        <label>Upload File (PDF Format)</label>
+        <br />
+        <p className="text-label">Format:</p>
+        <p className="text-label">
+          The Narrative of the proposal should not exceed 6 pages and should use NIH standard:
+          font 11 points or larger, no fewer than 6 lines per inch, and margins no smaller than 0.5"
+          (top, bottom, left, and right). It is recommended to use Arial, Georgia, Helvetica, or Palatino Linotype.
+        </p>
         <br />
         <br />
-        <div className="upload-btn-container">
-          <button className="upload-btn1">Click to upload</button>
-          <button className="del-icon-container">
-            <div className="del-icon"></div>
-          </button>
-        </div> 
+        {renderUploadSection()}
       </div>
-</div>
-  </div>
+    </div>
   );
+
+  return type === "Research" ? renderResearchContent() : renderNextGenContent();
 }
 
 export default GrantProposal;

--- a/react-app/ccf/src/pages/application-form/subquestions/NRNarrative.tsx
+++ b/react-app/ccf/src/pages/application-form/subquestions/NRNarrative.tsx
@@ -1,5 +1,6 @@
-import { useState, ChangeEvent } from "react";
+import { useState, useRef } from "react";
 import "./SubForm.css";
+import { uploadFileToStorage } from "../../../storage/storage";
 
 interface InformationProps {
   formData: any;
@@ -7,16 +8,55 @@ interface InformationProps {
 }
 
 function NRNarrative({ formData, setFormData }: InformationProps): JSX.Element {
-  const [explanation, setExplanation] = useState("");
-  const [institution, setInstitution] = useState("");
-  const [institutionAddress, setInstitutionAddress] = useState("");
-  const [institutionPhone, setInstitutionPhone] = useState("");
-  const [institutionEmail, setInstitutionEmail] = useState("");
-  const [amountRequested, setAmountRequested] = useState("");
-  const [timeframe, setTimeframe] = useState("");
-  const [additionalInfo, setAdditionalInfo] = useState("");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [uploadStatus, setUploadStatus] = useState<string>("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files[0]) {
+      console.log("File selected:", event.target.files[0].name);
+      setSelectedFile(event.target.files[0]);
+      setFormData({ ...formData, file: event.target.files[0] });
+      setUploadStatus("");
+    }
+  };
+
+  const handleUpload = async () => {
+    console.log("Upload button pressed");
+    if (!selectedFile) {
+      console.log("No file selected for upload");
+      setUploadStatus("Please select a file first");
+      return;
+    }
+
+    try {
+      console.log("Starting file upload:", selectedFile.name);
+      setUploadStatus("Uploading...");
+      await uploadFileToStorage(selectedFile);
+      console.log("File uploaded successfully:", selectedFile.name);
+      setUploadStatus("File uploaded successfully!");
+    } catch (error) {
+      console.error("Upload error:", error);
+      setUploadStatus("Upload failed. Please try again.");
+    }
+  };
+
+  const handleDelete = () => {
+    console.log("Delete button pressed");
+    setSelectedFile(null);
+    setFormData({ ...formData, file: null });
+    setUploadStatus("");
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleUploadClick = () => {
+    console.log("Upload button clicked - opening file selector");
+    fileInputRef.current?.click();
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setFormData((prevData: any) => ({ ...prevData, [name]: value }));
   };
@@ -35,7 +75,7 @@ function NRNarrative({ formData, setFormData }: InformationProps): JSX.Element {
           className="text-input2"
         />
 
-        <p className="text-label">We ask that you include other sources from which you are seeking to fund the Project and any other funding source, and/or the amount contributed by your Institution/Hospital. </p>
+        <p className="text-label">We ask that you include other sources from which you are seeking to fund the Project and any other funding source, and/or the amount contributed by your Institution/Hospital. </p>
         <input
           type="text"
           name="sources"
@@ -45,13 +85,9 @@ function NRNarrative({ formData, setFormData }: InformationProps): JSX.Element {
           required
           className="text-input2"
         />
-
-
-
-
       </div>
       <div className="right-container">
-      <p className="text-label">Amount Requested*</p>
+        <p className="text-label">Amount Requested*</p>
         <input
           type="text"
           name="amountRequested"
@@ -62,7 +98,7 @@ function NRNarrative({ formData, setFormData }: InformationProps): JSX.Element {
           className="text-input"
         />
 
-<p className="text-label">Time Frame*</p>
+        <p className="text-label">Time Frame*</p>
         <input
           type="text"
           name="timeframe"
@@ -73,8 +109,7 @@ function NRNarrative({ formData, setFormData }: InformationProps): JSX.Element {
           className="text-input"
         />
 
-
-<p className="text-label">Additional Information</p>
+        <p className="text-label">Additional Information</p>
         <input
           type="text"
           name="additionalInfo"
@@ -83,18 +118,39 @@ function NRNarrative({ formData, setFormData }: InformationProps): JSX.Element {
           placeholder="Type Here"
           className="text-input"
         />
-<br /><br /><br />
-<div className="file-upload">
-        <label>Upload File (PDF Format)</label>
-        <br />
-        <br />
-        <div className="upload-btn-container">
-          <button className="upload-btn1">Click to upload</button>
-          <button className="del-icon-container">
-            <div className="del-icon"></div>
-          </button>
-        </div> 
-      </div>
+        <br /><br /><br />
+        <div className="file-upload">
+          <label>Upload File (PDF Format)</label>
+          <br />
+          <br />
+          <div className="upload-btn-container">
+            <button 
+              className="upload-btn1" 
+              onClick={handleUploadClick}
+            >
+              {selectedFile ? selectedFile.name : "Click to upload"}
+            </button>
+            <input 
+              ref={fileInputRef}
+              type="file" 
+              accept=".pdf" 
+              onChange={handleFileChange}
+              style={{ display: "none" }} 
+              id="file-upload" 
+            />
+            {selectedFile && (
+              <button className="del-icon-container" onClick={handleDelete}>
+                <div className="del-icon"></div>
+              </button>
+            )}
+          </div>
+          {selectedFile && (
+            <button className="upload-btn1" onClick={handleUpload}>
+              Upload PDF
+            </button>
+          )}
+          {uploadStatus && <p className="upload-status">{uploadStatus}</p>}
+        </div>
       </div>
     </div>
   );

--- a/react-app/ccf/src/pages/application-form/subquestions/Review.tsx
+++ b/react-app/ccf/src/pages/application-form/subquestions/Review.tsx
@@ -25,7 +25,7 @@ function Review({ type, formData }: ReviewProps): JSX.Element {
       <br />
       <p className="text-label">Time Frame: {formData.timeframe}</p>
       <p className="text-label">Signature of Department Head or other person(s) designated to approve grant requests: {formData.signature}</p>
-      <p className="text-label">File: {formData.file}</p>
+      <p className="text-label">File: {formData.file?.name || 'No file uploaded'}</p>
     </div>
   </div>
   );
@@ -54,7 +54,7 @@ function Review({ type, formData }: ReviewProps): JSX.Element {
         <p className="text-label">Amount Requested: {formData.amountRequested}</p>
         <p className="text-label">Dates of Grant Project: {formData.grantProjDates}</p>
         <p className="text-label">Continuation of Current Funding: {formData.contCurrentFunds}</p>
-        <p className="text-label">File: {formData.file}</p>
+        <p className="text-label">File: {formData.file?.name || 'No file uploaded'}</p>
       </div>
     </div>
   );

--- a/storage.rules
+++ b/storage.rules
@@ -5,8 +5,8 @@ rules_version = '2';
 //    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
 service firebase.storage {
   match /b/{bucket}/o {
-    match /{allPaths=**} {
-      allow read, write: if false;
+    match /pdfs/{fileName} {
+      allow read, write: if request.auth != null;
     }
   }
 }


### PR DESCRIPTION
- Connected existing pdf upload functions to 3 application-form/ pages
- Pdfs go to the /pdf bucket in firebase storage
- Also showed name of pdf at review stage for all 3 forms.

# Type of change

Please delete options that are not relevant.

- [ ] Frontend New feature (non-breaking change which adds functionality)
- [ ] Backend New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce or screenshots.

- uploaded pdfs on frontend and saw reflected changes in firestore buckets.
- uploaded pdfs and went to review pages to see file name



# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
    - [ ] I have used components when necessary, minimize in-line CSS, and define types in a separate file within the types folder
    - [ ] Tested components and UI elements across various resolutions and display sizes using Chrome DevTools to ensure proper rendering and functionality.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new errors to the best of my knowledge
- [ ] There are no major merge conflicts at the time of creating this PR


