### PR TITLE
feat: Add indicator for unsaved changes on Awards page

### DIFF
--- a/react-app/ccf/src/pages/grant-awards/GrantAwards.css
+++ b/react-app/ccf/src/pages/grant-awards/GrantAwards.css
@@ -477,6 +477,13 @@
     background-color: #155db9;
 }
 
+.unsaved-changes-indicator {
+    margin-left: 15px;
+    color: #BE0019; /* Or a color that stands out */
+    font-style: italic;
+    font-size: 0.9em;
+}
+
 @media (max-width: 768px) {
     .modal-container {
         width: 95%;

--- a/react-app/ccf/src/pages/grant-awards/GrantAwards.tsx
+++ b/react-app/ccf/src/pages/grant-awards/GrantAwards.tsx
@@ -96,6 +96,7 @@ function GrantAwards(): JSX.Element {
         application: null as Application | null
     });
     const [savingChanges, setSavingChanges] = useState<{ [key: string]: boolean }>({});
+    const [hasUnsavedChanges, setHasUnsavedChanges] = useState<boolean>(false);
 
     const sidebarItems = getSidebarbyRole("admin");
 
@@ -176,6 +177,7 @@ function GrantAwards(): JSX.Element {
         }
 
         setApplications(updatedApplications);
+        setHasUnsavedChanges(true); // Indicate that there are unsaved changes
         // No firebase updates until save button is clicked
     };
 
@@ -312,9 +314,12 @@ function GrantAwards(): JSX.Element {
             for (let i = 0; i < applications.length; i++) {
                 await saveChangesToFirestore(i);
             }
+            setHasUnsavedChanges(false); // Reset after all changes are saved
             alert("All changes saved successfully!");
         } catch (error) {
             console.error("Error saving changes:", error);
+            // If there's an error, we keep hasUnsavedChanges as true,
+            // because some changes might not have been saved.
             alert("Error saving changes. Please try again.");
         }
     };
@@ -431,6 +436,11 @@ function GrantAwards(): JSX.Element {
                                 >
                                     Save All Changes
                                 </button>
+                                {hasUnsavedChanges && (
+                                    <span className="unsaved-changes-indicator">
+                                        You have unsaved changes.
+                                    </span>
+                                )}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Adds a visual indicator to the Awards page that appears when there are unsaved modifications to the 'Recommended' funding amounts.

- Introduces `hasUnsavedChanges` state in `GrantAwards.tsx`.
- Updates input handlers to set this state when changes are made.
- Resets the state when 'Save All Changes' is successful.
- Displays an indicator message when `hasUnsavedChanges` is true.
- Adds basic styling for the indicator.

# I wanted to test Jules by Google, so I had it do this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual indicator to alert users when there are unsaved changes in the grant awards form.
  * The indicator appears next to the "Save All Changes" button and updates automatically as changes are made or saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->