### PR TITLE
Lock application submission to the cycle the draft was created in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ create-empty-collections.js
 recreate-collections.js
 reset-firebase-admin.js
 reset-firebase.js
+
+/plans

--- a/firestore.rules
+++ b/firestore.rules
@@ -24,7 +24,7 @@ service cloud.firestore {
       allow read: if isAdmin() || isReviewer() || (isApplicant() && request.auth.uid == resource.data.creatorId);
       allow create: if isAdmin() || (isApplicant() && request.resource.data.creatorId == request.auth.uid);
       allow update: if isAdmin() || (isApplicant() && resource.data.creatorId == request.auth.uid && resource.data.status == 'draft');
-      allow delete: if isAdmin();
+      allow delete: if isAdmin() || (isApplicant() && resource.data.creatorId == request.auth.uid && resource.data.status == 'draft');
     }
     
     // FAQs collection rules

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -207,6 +207,7 @@ exports.submitApplication = onCall(async (request) => {
         // 9. Create application document
         const applicationDetails = {
             ...application,
+            status: 'submitted',
             decision: 'pending',
             creatorId: userId,
             applicationId: fileId,

--- a/react-app/ccf/package-lock.json
+++ b/react-app/ccf/package-lock.json
@@ -95,7 +95,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
       "integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.25.7",
@@ -760,7 +759,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.25.7.tgz",
       "integrity": "sha512-fyoj6/YdVtlv2ROig/J0fP7hh/wNO1MJGm1NR70Pg7jbkF+jOUL9joorqaCOQh06Y+LfgTagHzC8KqZ3MF782w==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.7"
       },
@@ -1582,7 +1580,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.7.tgz",
       "integrity": "sha512-vILAg5nwGlR9EXE8JIOX4NHXd49lrYbN8hnjffDtoULwpL9hUx/N55nqh2qd0q6FyNDfjl9V79ecKGvFbcSA0Q==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.7",
         "@babel/helper-module-imports": "^7.25.7",
@@ -2447,7 +2444,6 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2488,7 +2484,6 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
       "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2662,7 +2657,6 @@
       "version": "0.10.12",
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.12.tgz",
       "integrity": "sha512-fgBqe5j7GKv7/eMfyU4N1FdiW6O1EyrrVbMa8rJOT5MYNpCXqdL/5NNcLDStS1l6CN7h65a7jUNXmMnMSWo0sw==",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.9",
         "@firebase/logger": "0.4.2",
@@ -2715,7 +2709,6 @@
       "version": "0.2.42",
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.42.tgz",
       "integrity": "sha512-vPI0Aksk8ZuHywigyTxrx/oWbuD41kHxajfxRly7urHOFRiXKxf/q2ftgmcMVPfIeg0K02LzYNBmoh2PWzERpg==",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.10.12",
         "@firebase/component": "0.6.9",
@@ -2727,8 +2720,7 @@
     "node_modules/@firebase/app-types": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.2.tgz",
-      "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ==",
-      "peer": true
+      "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ=="
     },
     "node_modules/@firebase/auth": {
       "version": "1.7.9",
@@ -3117,7 +3109,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
       "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -4185,6 +4176,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.0.1.tgz",
       "integrity": "sha512-T5DNVnSD9pMbj4Jk/Uphz+yvj9dfpl2+EqsOuJtG12HxEihNG5pd3qzX5yM1Id4dDwKRvM3dPVcxyzavTFhJeA==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
@@ -4267,12 +4259,14 @@
     "node_modules/@mui/material/node_modules/react-is": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg=="
+      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
+      "peer": true
     },
     "node_modules/@mui/private-theming": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.0.1.tgz",
       "integrity": "sha512-1kQ7REYjjzDukuMfTbAjm3pLEhD7gUMC2bWhg9VD6f6sHzyokKzX0XHzlr3IdzNWBjPytGkzHpPIRQrUOoPLCQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.10",
         "@mui/utils": "^7.0.1",
@@ -4299,6 +4293,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.0.1.tgz",
       "integrity": "sha512-BeGe4xZmF7tESKhmctYrL54Kl25kGHPKVdZYM5qj5Xz76WM/poY+d8EmAqUesT6k2rbJWPp2gtOAXXinNCGunQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.10",
         "@emotion/cache": "^11.13.5",
@@ -4626,6 +4621,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -5020,6 +5016,7 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5038,6 +5035,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -5052,6 +5050,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -5060,6 +5059,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -5075,6 +5075,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -5085,12 +5086,14 @@
     "node_modules/@testing-library/dom/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "peer": true
     },
     "node_modules/@testing-library/dom/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5099,6 +5102,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -5590,7 +5594,6 @@
       "version": "18.3.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
       "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5731,7 +5734,6 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -5783,7 +5785,6 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -6115,7 +6116,6 @@
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6202,7 +6202,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7064,7 +7063,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -8049,8 +8047,7 @@
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.7",
@@ -8193,6 +8190,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8763,7 +8761,6 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11595,7 +11592,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -14757,7 +14753,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -15850,7 +15845,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -16203,7 +16197,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16425,7 +16418,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -16456,7 +16448,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16496,7 +16487,6 @@
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
       "integrity": "sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.16.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
@@ -16932,7 +16922,6 @@
       "version": "2.79.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -17165,7 +17154,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18629,7 +18617,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -19033,7 +19020,6 @@
       "version": "5.95.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
       "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -19101,7 +19087,6 @@
       "version": "4.15.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -19520,7 +19505,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/react-app/ccf/src/backend/application-filters.ts
+++ b/react-app/ccf/src/backend/application-filters.ts
@@ -29,16 +29,23 @@ export async function getFilteredApplications(filters: FilterOptions): Promise<A
             conditions.push(where('grantType', '==', filters.grantType));
         }
 
-        // Create the query with all conditions
+        // Apply all provided filter conditions to the query
+        if (conditions.length > 0) {
+            q = query(q, ...conditions);
+        }
 
         // Execute the query
         const querySnapshot = await getDocs(q);
 
-        // Map the results to the expected type
-        const applications = querySnapshot.docs.map(doc => ({
-            applicationId: doc.id,
-            ...doc.data()
-        })) as unknown as Array<Application>;
+        // Map the results to the expected type. Drafts share this collection, so
+        // exclude them (filtered client-side so submitted docs that predate the
+        // status field are still included).
+        const applications = querySnapshot.docs
+            .filter(doc => doc.data().status !== 'draft')
+            .map(doc => ({
+                applicationId: doc.id,
+                ...doc.data()
+            })) as unknown as Array<Application>;
 
         return applications;
     } catch (error) {
@@ -54,10 +61,15 @@ export async function getUsersCurrentCycleAppplications(): Promise<Array<Applica
     let q: Query<DocumentData> = collection(db, 'applications');
     q = query(q, where("creatorId", "==", user.uid), where("applicationCycle", "==", currentCycle.name));
     const querySnapshot = await getDocs(q);
-    return querySnapshot.docs.map(doc => ({
-        id: doc.id,
-        ...doc.data()
-    })) as unknown as Array<Application>;
+    return querySnapshot.docs
+        // Drafts live in the same collection; exclude them so they don't show up
+        // as "completed" submitted applications. (Filtered client-side so submitted
+        // docs that predate the status field are still included.)
+        .filter(doc => doc.data().status !== 'draft')
+        .map(doc => ({
+            id: doc.id,
+            ...doc.data()
+        })) as unknown as Array<Application>;
 }
 
 export async function getUsersAllApplications(): Promise<Array<Application>> {

--- a/react-app/ccf/src/index.tsx
+++ b/react-app/ccf/src/index.tsx
@@ -32,7 +32,7 @@ const functions = getFunctions(cong);
 
 //flag for local testing
 // change to true to run -+using emulator
-const useEmulator = false
+const useEmulator = true
 
 if (useEmulator) {
   connectFirestoreEmulator(db, '127.0.0.1', 8080);

--- a/react-app/ccf/src/index.tsx
+++ b/react-app/ccf/src/index.tsx
@@ -32,7 +32,7 @@ const functions = getFunctions(cong);
 
 //flag for local testing
 // change to true to run -+using emulator
-const useEmulator = true
+const useEmulator = false;
 
 if (useEmulator) {
   connectFirestoreEmulator(db, '127.0.0.1', 8080);

--- a/react-app/ccf/src/pages/admin-edit-info/AdminEditInformation.tsx
+++ b/react-app/ccf/src/pages/admin-edit-info/AdminEditInformation.tsx
@@ -295,9 +295,9 @@ function AdminEditInformation(): JSX.Element {
                                     onClick={async () => {
                                         const success = await updateCurrentCycleDeadlines({ allApplicationsDate });
                                         if (success) {
-                                            setAppDeadlineMessage("Application Deadline Updated!");
+                                            setAppDeadlineMessage("Deadline updated!");
                                         } else {
-                                            setAppDeadlineMessage("Failed to update. Please try again.");
+                                            setAppDeadlineMessage("Update failed");
                                         }
                                         setTimeout(() => setAppDeadlineMessage(null), 3000);
                                     }}
@@ -310,8 +310,8 @@ function AdminEditInformation(): JSX.Element {
                                         fontWeight: 'normal',
                                         borderRadius: '10px',
                                         '&:hover': { backgroundColor: '#003E83' },
-                                        minWidth: 'auto !important',
-                                        width: 'auto !important',
+                                        minWidth: '270px',
+                                        width: '270px',
                                         whiteSpace: 'nowrap',
                                     }}
                                 >{appDeadlineMessage ?? "Set Application Deadline"}</Button>
@@ -352,9 +352,9 @@ function AdminEditInformation(): JSX.Element {
                                     onClick={async () => {
                                         const success = await updateCurrentCycleDeadlines({ reviewerDate });
                                         if (success) {
-                                            setRevDeadlineMessage("Reviewer Deadline Updated!");
+                                            setRevDeadlineMessage("Deadline updated!");
                                         } else {
-                                            setRevDeadlineMessage("Failed to update. Please try again.");
+                                            setRevDeadlineMessage("Update failed");
                                         }
                                         setTimeout(() => setRevDeadlineMessage(null), 3000);
                                     }}
@@ -367,8 +367,8 @@ function AdminEditInformation(): JSX.Element {
                                         fontWeight: 'normal',
                                         borderRadius: '10px',
                                         '&:hover': { backgroundColor: '#003E83' },
-                                        minWidth: 'auto !important',
-                                        width: 'auto !important',
+                                        minWidth: '270px',
+                                        width: '270px',
                                         whiteSpace: 'nowrap',
                                     }}
                                 >{revDeadlineMessage ?? "Set Reviewer Deadline"}</Button>
@@ -409,9 +409,9 @@ function AdminEditInformation(): JSX.Element {
                                     onClick={async () => {
                                         const success = await updateCurrentCycleDeadlines({ postGrantReportDate });
                                         if (success) {
-                                            setPostGrantReportDeadlineMessage("Post-Grant Report Deadline Updated!");
+                                            setPostGrantReportDeadlineMessage("Deadline updated!");
                                         } else {
-                                            setPostGrantReportDeadlineMessage("Failed to update. Please try again.");
+                                            setPostGrantReportDeadlineMessage("Update failed");
                                         }
                                         setTimeout(() => setPostGrantReportDeadlineMessage(null), 3000);
                                     }}
@@ -424,8 +424,8 @@ function AdminEditInformation(): JSX.Element {
                                         fontWeight: 'normal',
                                         borderRadius: '10px',
                                         '&:hover': { backgroundColor: '#003E83' },
-                                        minWidth: 'auto !important',
-                                        width: 'auto !important',
+                                        minWidth: '270px',
+                                        width: '270px',
                                         whiteSpace: 'nowrap',
                                     }}
                                 >{postGrantReportDeadlineMessage ?? "Set Post-Grant Deadline"}</Button>

--- a/react-app/ccf/src/pages/admin-post-grant-reports/AdminPostGrantReports.tsx
+++ b/react-app/ccf/src/pages/admin-post-grant-reports/AdminPostGrantReports.tsx
@@ -61,6 +61,10 @@ function AdminPostGrantReports(): JSX.Element {
                 // Process all applications and filter for accepted ones
                 for (const doc of applicationsSnapshot.docs) {
                     const applicationData = doc.data() as ApplicationInfo;
+
+                    // Drafts share this collection; skip them outright.
+                    if ((applicationData as any).status === 'draft') continue;
+
                     const applicationId = doc.id; // Use the document ID
                     const decisionData = decisionDataMap[applicationId];
 

--- a/react-app/ccf/src/pages/application-form/ApplicationForm.tsx
+++ b/react-app/ccf/src/pages/application-form/ApplicationForm.tsx
@@ -8,7 +8,6 @@ import ApplicationQuestions from './subquestions/ApplicationQuestions';
 import ReviewApplication from './subquestions/Review';
 import GrantProposal from './subquestions/GrantProposal';
 import AboutGrant from './subquestions/AboutGrant';
-import { ResearchApplication } from '../../types/application-types';
 import { uploadResearchApplication } from '../../backend/applicant-form-submit';
 import { toast } from 'react-toastify';
 import { Modal } from '../../components/modal/modal';
@@ -92,11 +91,6 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
     const location = useLocation();
 
     useEffect(() => {
-        const savedDraft = localStorage.getItem('researchApplicationDraft');
-        if (savedDraft) {
-            setFormData(JSON.parse(savedDraft));
-        }
-
         getCurrentCycle().then(async cycle => {
             const updatedCycle = await checkAndUpdateCycleStageIfNeeded(cycle);
             setAppOpen(updatedCycle.stage === "Applications Open")
@@ -329,7 +323,18 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
         }
 
         try {
-            const application: ResearchApplication = formData as ResearchApplication;
+            // Strip draft-only/metadata fields so the submitted application is never
+            // tagged as a draft. When a saved draft is resumed, the entire Firestore
+            // doc (including status: 'draft', cycle ids and timestamps) is merged into
+            // formData; sending those through would make the canonical submitted
+            // document still look like a draft. The file is passed separately and the
+            // cloud function sets the canonical storage reference.
+            const application = { ...formData } as any;
+            [
+                'status', 'creatorId', 'applicantEmail', 'applicationCycleId',
+                'applicationCycle', 'createdAt', 'lastUpdated', 'grantType',
+                'decision', 'submitTime', 'applicationId', 'file'
+            ].forEach((key) => delete application[key]);
             if (formData.file) {
                 // Show loading toast
                 toast.info('Submitting application...');
@@ -339,7 +344,6 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
 
                 if (result.success) {
                     toast.success('Application submitted successfully!');
-                    localStorage.removeItem('researchApplicationDraft');
                     // The cloud function creates the canonical submitted application,
                     // so remove the working draft to avoid a duplicate appearing.
                     if (draftId) {

--- a/react-app/ccf/src/pages/application-form/ApplicationForm.tsx
+++ b/react-app/ccf/src/pages/application-form/ApplicationForm.tsx
@@ -14,7 +14,7 @@ import { toast } from 'react-toastify';
 import { Modal } from '../../components/modal/modal';
 import { getCurrentCycle, checkAndUpdateCycleStageIfNeeded } from '../../backend/application-cycle';
 import { auth } from '../..';
-import { collection, addDoc, updateDoc, doc, getDoc } from 'firebase/firestore';
+import { collection, addDoc, updateDoc, deleteDoc, doc, getDoc } from 'firebase/firestore';
 import { db } from '../..';
 
 type ApplicationFormProps = {
@@ -340,11 +340,14 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
                 if (result.success) {
                     toast.success('Application submitted successfully!');
                     localStorage.removeItem('researchApplicationDraft');
+                    // The cloud function creates the canonical submitted application,
+                    // so remove the working draft to avoid a duplicate appearing.
                     if (draftId) {
-                        await updateDoc(doc(db, 'applications', draftId), {
-                            status: 'submitted', 
-                            lastUpdated: new Date().toISOString()
-                        });
+                        try {
+                            await deleteDoc(doc(db, 'applications', draftId));
+                        } catch (cleanupErr) {
+                            console.error('Failed to delete draft after submission:', cleanupErr);
+                        }
                     }
                     navigate('/applicant/dashboard');
                 } else {

--- a/react-app/ccf/src/pages/application-form/ApplicationForm.tsx
+++ b/react-app/ccf/src/pages/application-form/ApplicationForm.tsx
@@ -87,6 +87,7 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
     const [modalContent, setModalContent] = useState<React.ReactNode>(null);
     const [appOpen, setAppOpen] = useState<boolean>(false);
     const [draftId, setDraftId] = useState<string | null>(null);
+    const [draftCycleId, setDraftCycleId] = useState<string | null>(null);
     const [draftCycle, setDraftCycle] = useState<string | null>(null);
     const location = useLocation();
 
@@ -128,6 +129,7 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
                 if (draftDoc.exists()) {
                     const data = draftDoc.data();
                     setDraftId(existingDraftId);
+                    setDraftCycleId(data.applicationCycleId ?? null);
                     setDraftCycle(data.applicationCycle ?? null);
                     setFormData(prev => ({ ...prev, ...data }));
                     setCurrentPage(2); // Skip past the About Grant page
@@ -180,6 +182,7 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
                 grantType: type === 'NextGen' ? 'nextgen' : 'research',
                 creatorId: currentUser.uid,
                 applicantEmail: currentUser.email,
+                applicationCycleId: cycle.id,
                 applicationCycle: cycle.name,
                 createdAt: new Date().toISOString(),
                 lastUpdated: new Date().toISOString(),
@@ -188,6 +191,7 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
 
             console.log('Draft created with ID:', draftRef.id);
             setDraftId(draftRef.id);
+            setDraftCycleId(cycle.id);
             setDraftCycle(cycle.name);
             setCurrentPage(2);
         } catch (err) {
@@ -281,10 +285,10 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
         }
 
         // Ensure the draft is being submitted during the same cycle it was created in.
-        if (draftCycle) {
+        if (draftCycleId) {
             try {
                 const currentCycle = await getCurrentCycle();
-                if (currentCycle.name !== draftCycle) {
+                if (currentCycle.id !== draftCycleId) {
                     setModalTitle('This Application Cycle Has Ended');
                     setModalContent(
                         <div style={{ whiteSpace: 'pre-line' }}>

--- a/react-app/ccf/src/pages/application-form/ApplicationForm.tsx
+++ b/react-app/ccf/src/pages/application-form/ApplicationForm.tsx
@@ -83,9 +83,11 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
     });
     const [errors, setErrors] = useState<any>({});
     const [isModalOpen, setIsModalOpen] = useState(false);
+    const [modalTitle, setModalTitle] = useState<string>('Please Fill Out All Missing Fields Before Submitting');
     const [modalContent, setModalContent] = useState<React.ReactNode>(null);
     const [appOpen, setAppOpen] = useState<boolean>(false);
     const [draftId, setDraftId] = useState<string | null>(null);
+    const [draftCycle, setDraftCycle] = useState<string | null>(null);
     const location = useLocation();
 
     useEffect(() => {
@@ -126,6 +128,7 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
                 if (draftDoc.exists()) {
                     const data = draftDoc.data();
                     setDraftId(existingDraftId);
+                    setDraftCycle(data.applicationCycle ?? null);
                     setFormData(prev => ({ ...prev, ...data }));
                     setCurrentPage(2); // Skip past the About Grant page
                 }
@@ -168,18 +171,24 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
                 return;
             }
 
+            // Stamp the draft with the cycle it was created in so it can only
+            // be submitted during that same cycle.
+            const cycle = await getCurrentCycle();
+
             const draftRef = await addDoc(collection(db, 'applications'), {
-                status: 'draft', 
-                grantType: type === 'NextGen' ? 'nextgen' : 'research', 
-                creatorId: currentUser.uid, 
-                applicantEmail: currentUser.email, 
-                createdAt: new Date().toISOString(), 
+                status: 'draft',
+                grantType: type === 'NextGen' ? 'nextgen' : 'research',
+                creatorId: currentUser.uid,
+                applicantEmail: currentUser.email,
+                applicationCycle: cycle.name,
+                createdAt: new Date().toISOString(),
                 lastUpdated: new Date().toISOString(),
                 ...formData
             });
 
             console.log('Draft created with ID:', draftRef.id);
             setDraftId(draftRef.id);
+            setDraftCycle(cycle.name);
             setCurrentPage(2);
         } catch (err) {
             console.error('Error creating draft:', err);
@@ -265,12 +274,41 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
                     Applications Are Closed
                 </div>
             );
+            setModalTitle('Applications Are Closed');
             setModalContent(formattedContent);
             setIsModalOpen(true);
             return;
         }
 
+        // Ensure the draft is being submitted during the same cycle it was created in.
+        if (draftCycle) {
+            try {
+                const currentCycle = await getCurrentCycle();
+                if (currentCycle.name !== draftCycle) {
+                    setModalTitle('This Application Cycle Has Ended');
+                    setModalContent(
+                        <div style={{ whiteSpace: 'pre-line' }}>
+                            {`This application was started during the "${draftCycle}" cycle, which has since ended. Applications can only be submitted during the cycle in which they were created.\n\nPlease contact the Children's Cancer Foundation (CCF) for assistance.`}
+                        </div>
+                    );
+                    setIsModalOpen(true);
+                    return;
+                }
+            } catch (error) {
+                console.error('Error verifying application cycle:', error);
+                setModalTitle('Unable to Verify Application Cycle');
+                setModalContent(
+                    <div style={{ whiteSpace: 'pre-line' }}>
+                        {`We couldn't verify the current application cycle. Please try again later, or contact the Children's Cancer Foundation (CCF) for assistance.`}
+                    </div>
+                );
+                setIsModalOpen(true);
+                return;
+            }
+        }
+
         if (Object.keys(invalidSections).length > 0) {
+            setModalTitle('Please Fill Out All Missing Fields Before Submitting');
             const formattedContent = (
                 <div style={{ whiteSpace: 'pre-line' }}>
                     {Object.entries(invalidSections).map(([section, fields]) => (
@@ -367,7 +405,7 @@ function ApplicationForm({ type }: ApplicationFormProps): JSX.Element {
             <Modal
                 isOpen={isModalOpen}
                 onClose={() => setIsModalOpen(false)}
-                title="Please Fill Out All Missing Fields Before Submitting"
+                title={modalTitle}
             >
                 {modalContent}
             </Modal>

--- a/react-app/ccf/src/pages/application-form/NRApplicationForm.tsx
+++ b/react-app/ccf/src/pages/application-form/NRApplicationForm.tsx
@@ -47,6 +47,7 @@ function NRApplicationForm(): JSX.Element {
     const [modalTitle, setModalTitle] = useState('Please Fill Out All Missing Fields Before Submitting');
     const [modalContent, setModalContent] = useState<React.ReactNode>(null);
     const [draftId, setDraftId] = useState<string | null>(null);
+    const [draftCycleId, setDraftCycleId] = useState<string | null>(null);
     const [draftCycle, setDraftCycle] = useState<string | null>(null);
     const location = useLocation();
 
@@ -88,6 +89,7 @@ function NRApplicationForm(): JSX.Element {
                 if (draftDoc.exists()) {
                     const data = draftDoc.data();
                     setDraftId(existingDraftId);
+                    setDraftCycleId(data.applicationCycleId ?? null);
                     setDraftCycle(data.applicationCycle ?? null);
                     setFormData(prev => ({ ...prev, ...data }));
                     setCurrentPage(2);
@@ -139,6 +141,7 @@ function NRApplicationForm(): JSX.Element {
                 grantType: 'nonresearch',
                 creatorId: currentUser.uid,
                 applicantEmail: currentUser.email,
+                applicationCycleId: cycle.id,
                 applicationCycle: cycle.name,
                 createdAt: new Date().toISOString(),
                 lastUpdated: new Date().toISOString(),
@@ -147,6 +150,7 @@ function NRApplicationForm(): JSX.Element {
 
             console.log('Draft created with ID:', draftRef.id);
             setDraftId(draftRef.id);
+            setDraftCycleId(cycle.id);
             setDraftCycle(cycle.name);
             setCurrentPage(2);
         } catch (err) {
@@ -197,10 +201,10 @@ function NRApplicationForm(): JSX.Element {
         }
 
         // Ensure the draft is being submitted during the same cycle it was created in.
-        if (draftCycle) {
+        if (draftCycleId) {
             try {
                 const currentCycle = await getCurrentCycle();
-                if (currentCycle.name !== draftCycle) {
+                if (currentCycle.id !== draftCycleId) {
                     setModalTitle('This Application Cycle Has Ended');
                     setModalContent(
                         <div style={{ whiteSpace: 'pre-line' }}>

--- a/react-app/ccf/src/pages/application-form/NRApplicationForm.tsx
+++ b/react-app/ccf/src/pages/application-form/NRApplicationForm.tsx
@@ -7,7 +7,6 @@ import NRInformation from './subquestions/NRInformation';
 import NRNarrative from './subquestions/NRNarrative';
 import ReviewApplication from './subquestions/Review';
 import AboutGrant from './subquestions/AboutGrant';
-import { NonResearchApplication } from '../../types/application-types';
 import { uploadNonResearchApplication } from '../../backend/applicant-form-submit';
 import { toast } from 'react-toastify';
 import { validateEmail, validatePhoneNumber} from '../../utils/validation';
@@ -52,11 +51,6 @@ function NRApplicationForm(): JSX.Element {
     const location = useLocation();
 
     useEffect(() => {
-        const savedDraft = localStorage.getItem('nonResearchApplicationDraft');
-        if (savedDraft) {
-            setFormData(JSON.parse(savedDraft));
-        }
-
         getCurrentCycle().then(async cycle => {
             const updatedCycle = await checkAndUpdateCycleStageIfNeeded(cycle);
             setAppOpen(updatedCycle.stage === "Applications Open")
@@ -245,7 +239,18 @@ function NRApplicationForm(): JSX.Element {
         }
 
         try {
-            const application: NonResearchApplication = formData as NonResearchApplication;
+            // Strip draft-only/metadata fields so the submitted application is never
+            // tagged as a draft. When a saved draft is resumed, the entire Firestore
+            // doc (including status: 'draft', cycle ids and timestamps) is merged into
+            // formData; sending those through would make the canonical submitted
+            // document still look like a draft. The file is passed separately and the
+            // cloud function sets the canonical storage reference.
+            const application = { ...formData } as any;
+            [
+                'status', 'creatorId', 'applicantEmail', 'applicationCycleId',
+                'applicationCycle', 'createdAt', 'lastUpdated', 'grantType',
+                'decision', 'submitTime', 'applicationId', 'file'
+            ].forEach((key) => delete application[key]);
             if (formData.file) {
                 toast.info('Submitting application...');
 
@@ -253,7 +258,6 @@ function NRApplicationForm(): JSX.Element {
 
                 if (result.success) {
                     toast.success('Application submitted successfully!');
-                    localStorage.removeItem('nonResearchApplicationDraft');
                     // The cloud function creates the canonical submitted application,
                     // so remove the working draft to avoid a duplicate appearing.
                     if (draftId) {

--- a/react-app/ccf/src/pages/application-form/NRApplicationForm.tsx
+++ b/react-app/ccf/src/pages/application-form/NRApplicationForm.tsx
@@ -14,7 +14,7 @@ import { validateEmail, validatePhoneNumber} from '../../utils/validation';
 import { getCurrentCycle, checkAndUpdateCycleStageIfNeeded } from '../../backend/application-cycle';
 import { Modal } from '../../components/modal/modal';
 import { auth } from '../..';
-import { collection, addDoc, updateDoc, doc, getDoc } from 'firebase/firestore';
+import { collection, addDoc, updateDoc, deleteDoc, doc, getDoc } from 'firebase/firestore';
 import { db } from '../..';
 
 function NRApplicationForm(): JSX.Element {
@@ -254,11 +254,14 @@ function NRApplicationForm(): JSX.Element {
                 if (result.success) {
                     toast.success('Application submitted successfully!');
                     localStorage.removeItem('nonResearchApplicationDraft');
+                    // The cloud function creates the canonical submitted application,
+                    // so remove the working draft to avoid a duplicate appearing.
                     if (draftId) {
-                        await updateDoc(doc(db, 'applications', draftId), {
-                            status: 'submitted', 
-                            lastUpdated: new Date().toISOString()
-                        });
+                        try {
+                            await deleteDoc(doc(db, 'applications', draftId));
+                        } catch (cleanupErr) {
+                            console.error('Failed to delete draft after submission:', cleanupErr);
+                        }
                     }
                     navigate('/applicant/dashboard');
                 } else {

--- a/react-app/ccf/src/pages/application-form/NRApplicationForm.tsx
+++ b/react-app/ccf/src/pages/application-form/NRApplicationForm.tsx
@@ -47,6 +47,7 @@ function NRApplicationForm(): JSX.Element {
     const [modalTitle, setModalTitle] = useState('Please Fill Out All Missing Fields Before Submitting');
     const [modalContent, setModalContent] = useState<React.ReactNode>(null);
     const [draftId, setDraftId] = useState<string | null>(null);
+    const [draftCycle, setDraftCycle] = useState<string | null>(null);
     const location = useLocation();
 
     useEffect(() => {
@@ -87,6 +88,7 @@ function NRApplicationForm(): JSX.Element {
                 if (draftDoc.exists()) {
                     const data = draftDoc.data();
                     setDraftId(existingDraftId);
+                    setDraftCycle(data.applicationCycle ?? null);
                     setFormData(prev => ({ ...prev, ...data }));
                     setCurrentPage(2);
                 }
@@ -128,18 +130,24 @@ function NRApplicationForm(): JSX.Element {
                 return;
             }
 
+            // Stamp the draft with the cycle it was created in so it can only
+            // be submitted during that same cycle.
+            const cycle = await getCurrentCycle();
+
             const draftRef = await addDoc(collection(db, 'applications'), {
                 status: 'draft',
                 grantType: 'nonresearch',
                 creatorId: currentUser.uid,
-                applicantEmail: currentUser.email, 
-                createdAt: new Date().toISOString(), 
-                lastUpdated: new Date().toISOString(), 
+                applicantEmail: currentUser.email,
+                applicationCycle: cycle.name,
+                createdAt: new Date().toISOString(),
+                lastUpdated: new Date().toISOString(),
                 ...formData
             });
 
             console.log('Draft created with ID:', draftRef.id);
             setDraftId(draftRef.id);
+            setDraftCycle(cycle.name);
             setCurrentPage(2);
         } catch (err) {
             console.error('Error creating draft:', err);
@@ -186,6 +194,33 @@ function NRApplicationForm(): JSX.Element {
             );
             setIsModalOpen(true);
             return;
+        }
+
+        // Ensure the draft is being submitted during the same cycle it was created in.
+        if (draftCycle) {
+            try {
+                const currentCycle = await getCurrentCycle();
+                if (currentCycle.name !== draftCycle) {
+                    setModalTitle('This Application Cycle Has Ended');
+                    setModalContent(
+                        <div style={{ whiteSpace: 'pre-line' }}>
+                            {`This application was started during the "${draftCycle}" cycle, which has since ended. Applications can only be submitted during the cycle in which they were created.\n\nPlease contact the Children's Cancer Foundation (CCF) for assistance.`}
+                        </div>
+                    );
+                    setIsModalOpen(true);
+                    return;
+                }
+            } catch (error) {
+                console.error('Error verifying application cycle:', error);
+                setModalTitle('Unable to Verify Application Cycle');
+                setModalContent(
+                    <div style={{ whiteSpace: 'pre-line' }}>
+                        {`We couldn't verify the current application cycle. Please try again later, or contact the Children's Cancer Foundation (CCF) for assistance.`}
+                    </div>
+                );
+                setIsModalOpen(true);
+                return;
+            }
         }
 
         if (Object.keys(invalidSections).length > 0) {

--- a/react-app/ccf/src/pages/assign-reviewers-page/AssignReviewers.tsx
+++ b/react-app/ccf/src/pages/assign-reviewers-page/AssignReviewers.tsx
@@ -149,6 +149,10 @@ const AssignReviewersPage: React.FC = () => {
         for (const doc of applicationsSnapshot.docs) {
           const data = doc.data();
 
+          // Drafts share this collection; skip them so half-finished applications
+          // aren't shown as assignable to reviewers.
+          if (data.status === 'draft') continue;
+
           // Get review information from the reviews collection
           let primaryReviewerId: string | undefined;
           let secondaryReviewerId: string | undefined;

--- a/react-app/ccf/src/pages/create-acc-applicants/CreateAccApplicant.tsx
+++ b/react-app/ccf/src/pages/create-acc-applicants/CreateAccApplicant.tsx
@@ -33,6 +33,9 @@ function AccountPageApplicants(): JSX.Element {
 
   const [institutionError, setInstitutionError] = useState(false);
 
+  //error returned from account creation
+  const [signupError, setSignupError] = useState<string | null>(null);
+
   const navigate = useNavigate();
 
   useEffect(() => { }, [
@@ -66,6 +69,7 @@ function AccountPageApplicants(): JSX.Element {
       e.preventDefault();
       return;
     }
+    setSignupError(null);
     try {
       const userData: UserData = {
         email: email,
@@ -77,8 +81,15 @@ function AccountPageApplicants(): JSX.Element {
       }
       await addApplicantUser(userData, pwd)
       navigate("/Login");
-    } catch (e) {
+    } catch (e: any) {
       console.log(e)
+      const code = e?.code;
+      const message = typeof e?.message === "string" ? e.message : "";
+      if (code === "auth/email-already-in-use" || message.includes("EMAIL_EXISTS")) {
+        setSignupError("An account with this email already exists. Please log in instead.");
+      } else {
+        setSignupError("Something went wrong while creating your account. Please try again.");
+      }
     }
   };
 
@@ -148,6 +159,7 @@ function AccountPageApplicants(): JSX.Element {
                 onChange={(e) => {
                   setEmail(e.target.value);
                   checkEmail(e.target.value);
+                  setSignupError(null);
                 }}
                 className="input"
               />
@@ -233,6 +245,10 @@ function AccountPageApplicants(): JSX.Element {
               </select>
               {institutionError && (
                 <p className="validation">Please select a valid institution</p>
+              )}
+
+              {signupError && (
+                <p className="validation">{signupError}</p>
               )}
 
               <p className="acc-req2">

--- a/react-app/ccf/src/pages/grant-awards/GrantAwards.tsx
+++ b/react-app/ccf/src/pages/grant-awards/GrantAwards.tsx
@@ -199,6 +199,11 @@ function GrantAwards(): JSX.Element {
       // First, collect all application data and IDs
       for (const doc of querySnapshot.docs) {
         const data: any = doc.data();
+
+        // Drafts share this collection; skip them so unsubmitted applications
+        // don't appear in the grant awards list.
+        if (data.status === "draft") continue;
+
         applicationIds.push(doc.id);
 
         // Get final score from application document (stored when both reviews are completed)

--- a/react-app/ccf/src/pages/post-grant-report/PostGrantReportPage.tsx
+++ b/react-app/ccf/src/pages/post-grant-report/PostGrantReportPage.tsx
@@ -338,6 +338,13 @@ function PostGrantReportPage(): JSX.Element {
         );
     }
 
+    const isFormComplete = Boolean(
+        report &&
+        formData.investigatorName.trim() &&
+        formData.institutionName.trim() &&
+        formData.attestationDate.trim()
+    );
+
     return (
         <>
             {showConfetti && <Confetti />}
@@ -466,22 +473,20 @@ function PostGrantReportPage(): JSX.Element {
                                 </div>
 
                                 <div className="PostGrantReport-submit">
-                                    
-                                <button
-                                    className="application-btn"
-                                    onClick={handleSubmit}
-                                    disabled={loading}
-                                >
-                                    {loading ? 'Submitting...' : 'Submit Report'}
-                                </button>
-
-                                <button
-                                        className="cancel-button"
+                                    <button
+                                        className="application-btn"
                                         onClick={() => navigate('/applicant/dashboard')}
                                     >
                                         Cancel
                                     </button>
 
+                                    <button
+                                        className="application-btn"
+                                        onClick={handleSubmit}
+                                        disabled={loading || !isFormComplete}
+                                    >
+                                        {loading ? 'Submitting...' : 'Submit Report'}
+                                    </button>
                                 </div>
 
                             </div>


### PR DESCRIPTION
# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] Frontend New feature (non-breaking change which adds functionality)
- [ X] Backend New feature (non-breaking change which adds functionality)
- [ ] Major Breaking change (breaking change will will require updating/changing major aspects of the site)

# How Has This Been Tested?

- Manual Testing


# Checklist:
- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my code
    - [ X] I have used components when necessary, minimize in-line CSS, and define types in a separate file within the types folder
    - [ X] Tested components and UI elements across various resolutions and display sizes using Chrome DevTools to ensure proper rendering and functionality.
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] My changes generate no new errors to the best of my knowledge
- [ X] There are no major merge conflicts at the time of creating this PR




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Application drafts are now saved with their grant cycle and submissions are blocked if the draft’s cycle doesn’t match the current one, with updated modal messaging.
  * Drafts are consistently excluded from admin/reviewer/awards views and filtering, preventing draft entries from appearing in lists.
  * Post-grant “Submit Report” is disabled until the report and all attestation fields are filled in.
* **Security / Access**
  * Draft application deletion is now allowed for admins and the original draft owner (only when status is `draft`).
* **UI Improvements**
  * Improved signup error messaging, standardized admin deadline notifications, and adjusted related button sizing/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->